### PR TITLE
update POIUtility to handle LONGVARCHAR

### DIFF
--- a/lib/POIUtility.cfc
+++ b/lib/POIUtility.cfc
@@ -978,6 +978,10 @@ component {
 
 						LOCAL.DataMapCast = "int";
 
+					} else if (REFindNoCase( "varchar", LOCAL.DataMapValue )){
+						// check for varchar here so we can intercept "longvarchar" before the "long" numeric check
+						LOCAL.DataMapCast = "string";
+						
 					} else if (REFindNoCase( "long", LOCAL.DataMapValue )){
 
 						LOCAL.DataMapCast = "long";


### PR DESCRIPTION
Update POIUtility to handle LONGVARCHAR SQL metadata. Check is done before the "long" check so that the field is not interpreted as a "long" numeric field type.